### PR TITLE
Remove getdeb/playdeb from list of repos

### DIFF
--- a/repologyapp/templates/supported_repos.html
+++ b/repologyapp/templates/supported_repos.html
@@ -1,7 +1,7 @@
 <ul>
 	<li><b>Linux repositories:</b> Adélie, Alpine, ALT, antiX, AOSC, Arch and AUR, BlackArch, Calculate, CentOS, CRUX, Debian, Deepin, Devuan, Distri, ELRepo, Entware-ng, EPEL, Exherbo, Fedora, Funtoo, Gentoo, Guix, GoboLinux, Hyperbola, KaOS, KISS, Kwort, Linuxbrew, Maemo, Mageia, Manjaro, Mer Project, Mint, MX Linux, Nix, OpenMandriva, openSUSE, OpenWrt, Parabola, Pardus, Parrot, PCLinuxOS, Pisi, PLD Linux, PureOS, Raspbian, Rosa, Sabayon, Salix, SlackBuilds, Slackware, SliTaz, Solus, SparkyLinux, SteamOS, T2 SDE, Tails, Trisquel, Ubuntu, Void, Whonix</li>
 	<li><b>*BSD repositories:</b> DragonFly DPorts, FreeBSD ports, OpenBSD packages, pkgsrc, Ravenports</li>
-	<li><b>Third party repositories:</b> Deb Multimedia, Gentoo overlays, GetDeb/Playdeb, KDE neon, OpenPKG, openSUSE additional repositories, PackMan, UnitedRPMs, RPM Fusion</li>
+	<li><b>Third party repositories:</b> Deb Multimedia, Gentoo overlays, KDE neon, OpenPKG, openSUSE additional repositories, PackMan, UnitedRPMs, RPM Fusion</li>
 	<li><b>Other *nix repositories:</b> AIX Open Source Packages, Homebrew, HP-UX, OpenIndiana, MacPorts, Rudix</li>
 	<li><b>And non-*nix repositories:</b> Chocolatey, Cygwin, F-Droid, HaikuPorts, just-install, MSYS2 (msys2, mingw), Npackd, OS4Depot, ReactOS rapps, Scoop, Termux, Vcpkg, YACP</li>
 	<li><b>Upstream module collections or programming language specific package managers:</b> Buckaroo, CPAN, CRAN, crates.io, GNU ELPA, Hackage, LuaRocks, MELPA, <span class="unsupported-repository" title="Not currently available due to no way to get the package data">PyPi</span>, RubyGems, Stackage</li>


### PR DESCRIPTION
This is a followup to my other PR (https://github.com/repology/repology-updater/pull/934) to remove getdeb/playdeb from the updates.