### PR TITLE
Add tooltip to version numbers in package page

### DIFF
--- a/repologyapp/templates/project-versions.html
+++ b/repologyapp/templates/project-versions.html
@@ -37,9 +37,9 @@
 		<td class="text-center">
 			{%- set vuln = package.flags is has_flag_at(16) -%}
 			{%- if package.origversion != package.version -%}
-			<span class="version version-big version-{{ package.versionclass|css_for_versionclass }} version-property-fixed" title="Normalized from &quot;{{ package.origversion }}&quot;">
+			<span class="version version-big version-{{ package.versionclass|css_for_versionclass }} version-property-fixed" title="{{ package.versionclass|css_for_versionclass }} version; normalized from &quot;{{ package.origversion }}&quot;">
 			{%- else -%}
-			<span class="version version-big version-{{ package.versionclass|css_for_versionclass }}">
+			<span class="version version-big version-{{ package.versionclass|css_for_versionclass }}" title="{{ package.versionclass|css_for_versionclass }} version">
 			{%- endif -%}
 				{%- if package.url is not none %}
 				<a href="{{ package.url }}">{{ package.version }}</a>


### PR DESCRIPTION
The meaning of the colors alone is not self-evident without a legend like what's shown in the [main page](https://repology.org/) (see [repologyapp/templates/versionclass_list.html](https://github.com/repology/repology-webapp/blob/44a3d7f1e9b4af7dd939b136e3aba06467e482b5/repologyapp/templates/versionclass_list.html)).

This way, it will be possible to hover over a given version, and the tooltip will reveal what type (i.e. class) of version it is.