### PR TITLE
Make devel color distinguishable from 'version-newest' color

### DIFF
--- a/repologyapp/static/repology.v21.css
+++ b/repologyapp/static/repology.v21.css
@@ -207,7 +207,7 @@
 }
 
 .version-devel {
-    background-color: #5bbc9d;
+    background-color: #2f80ed;
 }
 
 .version-newest {

--- a/repologyapp/templates/layout.html
+++ b/repologyapp/templates/layout.html
@@ -11,7 +11,7 @@
 {% endblock %}
 	<title>{% block title %}Repology{% endblock %}</title>
 	<link rel="stylesheet" href="{{ url_for("static", filename="bootstrap.min.v3.3.7.css") }}">
-	<link rel="stylesheet" href="{{ url_for("static", filename="repology.v20.css") }}">
+	<link rel="stylesheet" href="{{ url_for("static", filename="repology.v21.css") }}">
 	<link rel="icon" href="{{ url_for("static", filename="repology.v1.ico") }}" sizes="16x16 32x32 64x64" type="image/x-icon">
 	<link rel="search" type="application/opensearchdescription+xml" title="Repology packages" href="{{ url_for("opensearch_project") }}">
 	<link rel="search" type="application/opensearchdescription+xml" title="Repology maintainers" href="{{ url_for("opensearch_maintainer") }}">


### PR DESCRIPTION
The current color is almost indistinguishable from the color for
'version-newest'.

Compare the pair of colors
- before: https://www.joedolson.com/tools/color-contrast.php?type=hex&color=%235bbc9d&color2=%235cb85c&alpha=1
- after : https://www.joedolson.com/tools/color-contrast.php?type=hex&color=%232f80ed&color2=%235cb85c&alpha=1