### PR TITLE
Allow to specify minimum cell width for vertical badge

### DIFF
--- a/repologyapp/views/badges.py
+++ b/repologyapp/views/badges.py
@@ -67,6 +67,10 @@ def badge_vertical_allrepos(name: str) -> Response:
 
     header = args.get('header')
     minversion = args.get('minversion')
+    try:
+        minwidth = max(60, int(args.get('minwidth')))
+    except:
+        minwidth = 60
 
     repo_filter = RepositoryFilter(args)
 
@@ -85,7 +89,7 @@ def badge_vertical_allrepos(name: str) -> Response:
 
             cells.append([
                 BadgeCell(repometadata[reponame]['desc'], align='r'),
-                BadgeCell(version, color=color, truncate=13, minwidth=60)
+                BadgeCell(version, color=color, truncate=13, minwidth=minwidth)
             ])
 
     try:


### PR DESCRIPTION
My use case is basically trying to display 2 “related” packages in terms of repology detection, which are in fact the same package.

Displaying the 2 badges below each other and skipping the 2nd header is getting close to being satisfying but the very large width disparity is a little strange:

![image](https://user-images.githubusercontent.com/6126377/225349467-67dd4cdc-d145-4ace-875f-2086a086b4bb.png)

This PR allows to set a minwidth of a cell via a parameter, so I can specify `columns=2&minwidth=200` and have a more similar display across both badges, thus increasing readability.

60 remains the minimum, and the fallback if no value or an incorrect value is passed.