### PR TITLE
Change link to database dumps

### DIFF
--- a/repologyapp/templates/api.html
+++ b/repologyapp/templates/api.html
@@ -10,7 +10,7 @@
 
 <h3>Terms of use</h3>
 
-<p>Bulk requests to this API are discouraged, consider requesting a <a href="https://github.com/repology/repology-exports">bulk export</a>. Bulk clients must identify themselves with a custom <code>user-agent</code>, referring to a description of the client and a way to report misbehavior (such as GitHub repository with an issue tracker). Bulk clients must not do more than one request per second. Miscomplying clients will be blocked.</p>
+<p>Bulk requests to this API are discouraged, consider using a <a href="https://dumps.repology.org/README.txt">database dump</a>. Bulk clients must identify themselves with a custom <code>user-agent</code>, referring to a description of the client and a way to report misbehavior (such as GitHub repository with an issue tracker). Bulk clients must not do more than one request per second. Miscomplying clients will be blocked.</p>
 
 <h3>Introduction</h3>
 


### PR DESCRIPTION
The current link is to a 5 year old repo. It'd be better to link to the database dumps which seems to running regularly?