### PR TITLE
fix tick for build logs

### DIFF
--- a/repologyapp/templates/repositories/fields.html
+++ b/repologyapp/templates/repositories/fields.html
@@ -58,7 +58,7 @@
 				{%- else %}<span class="text-danger" title="Repository must provide link to package sources">✘</span>{% endif -%}
 			</td>
 			<td class="text-center">{% if 11 in link_types or 12 in link_types %}✔{% endif %}</td>
-			<td class="text-center">{% if 13 in link_types or 14 in link_types %}✔{% endif %}</td>
+			<td class="text-center">{% if 13 in link_types or 14 in link_types or 27 in link_types %}✔{% endif %}</td>
 			<td class="text-center">
 				{%- if 'srcname' in fields %}<abbr title="source (package) name">s</abbr>{% endif -%}
 				{%- if 'binname' in fields %}<abbr title="binary (package) name">b</abbr>{% endif -%}


### PR DESCRIPTION
Fedora and NixOS (with https://github.com/repology/repology-updater/pull/1403) do not show a tick for having build logs in the fields tab of repository data, this fixes that.